### PR TITLE
Fix cross-tab navigation warning

### DIFF
--- a/NavLab/Features/Home/HomeScreen.swift
+++ b/NavLab/Features/Home/HomeScreen.swift
@@ -14,8 +14,7 @@ struct HomeScreen: View {
         List {
             Section("Navigation") {
                 Button("Go to Product #42") {
-                    coordinator.switchTab(.catalog)
-                    coordinator.open(.product(id: 42), asRoot: true)
+                    coordinator.open(.product(id: 42), in: .catalog, asRoot: true)
                 }
                 Button("Open Settings (sheet)") { coordinator.presentSheet(.settings) }
             }

--- a/NavLab/Navigation/FlowCoordinator.swift
+++ b/NavLab/Navigation/FlowCoordinator.swift
@@ -21,10 +21,14 @@ final class FlowCoordinator: ObservableObject {
 
     func open(_ route: Route, asRoot: Bool = false) {
         guard !isDebounced() else { return }
-        if asRoot {
-            state.currentPath = [route]
-        } else {
-            state.currentPath.append(route)
+        updatePath(route, in: state.selectedTab, asRoot: asRoot)
+    }
+
+    func open(_ route: Route, in tab: Tab, asRoot: Bool = false) {
+        guard !isDebounced() else { return }
+        updatePath(route, in: tab, asRoot: asRoot)
+        if state.selectedTab != tab {
+            state.selectedTab = tab
         }
     }
 
@@ -48,5 +52,13 @@ final class FlowCoordinator: ObservableObject {
         let now = Date()
         defer { lastCommandAt = now }
         return now.timeIntervalSince(lastCommandAt) < debounce
+    }
+
+    private func updatePath(_ route: Route, in tab: Tab, asRoot: Bool) {
+        if asRoot {
+            state.pathPerTab[tab] = [route]
+        } else {
+            state.pathPerTab[tab, default: []].append(route)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a FlowCoordinator helper that updates tab paths before switching selections
- use the new API for the Home screen shortcut so the catalog path is primed before the tab renders

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf3db2ac74832883d5e6ed4730de91